### PR TITLE
Fix parsing of bad KML files

### DIFF
--- a/src/Adapter/KML.php
+++ b/src/Adapter/KML.php
@@ -169,10 +169,17 @@ class KML implements GeoAdapter
         $pointArray = [];
         $hasZ = false;
         $hasM = false;
+
         foreach ($coordinates as $set) {
             $hasZ = $hasZ || (isset($set[2]) && $set[2]);
             $hasM = $hasM || (isset($set[3]) && $set[3]);
         }
+
+
+        if (count($coordinates) == 1) {
+            $coordinates[1] = $coordinates[0];
+        }
+
         foreach ($coordinates as $set) {
             $pointArray[] = new Point(
                 $set[0],
@@ -181,7 +188,7 @@ class KML implements GeoAdapter
                 ($hasM ? (isset($set[3]) ? $set[3] : 0) : null)
             );
         }
-        
+
         return new LineString($pointArray);
     }
 


### PR DESCRIPTION
Hi @swen100, 

thanks for creating this fork. We would like to use it in our Project to parse geographic files. However, some of the manually drawn files from Google have Linestrings with only one point inside (apparently Google doesnt care about them) - I just made a quick fix, by creating a second point at the same location.
A much better solution would be to just ignore those linestrings, but this would require a bigger code change. I would like to discuss this with you - Or if you are okay with it like this, feel free to merge it.

Thank you very much in advance!